### PR TITLE
Make listeners use an interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,26 +83,6 @@ Here is an abridged version (with comments) of the config file:
 }
 ```
 
-# To Do
-
-This is my first real chatbot written in Go and it isn't very perfect...
-
-Here's my list of things I want to improve on it:
-
-* Make the Listener system implement Golang interfaces.
-  * There's `src/listeners/listeners.go` that defines an interface, but it's
-    not being used by the actual listeners. Instead it's just a reference for
-    developers (me) to know what functions the listener should have.
-  * I tried making it an interface originally but it was proving to be pretty
-    difficult (errors like "Can't use a `*SlackListener` in place of a
-    `*Listener` and stuff...")
-  * As a consequence, the main code (`src/scarecrow.go`) needs special logic and
-    extra lines of code to handle the Slack vs. Console listeners, instead of
-    (ideally) being able to just have an array of listeners it can loop over
-    and deal with.
-* Revisit how I'm using Goroutines and see if it's the optimal way of doing it.
-  * See below for the Goroutine layout of this app.
-
 ## Goroutines
 
 The main thread does all the work up until the `Start()` function is called.

--- a/cmd/scarecrow/main.go
+++ b/cmd/scarecrow/main.go
@@ -6,8 +6,10 @@ package main
 import (
 	"flag"
 	"fmt"
-	scarecrow "github.com/aichaos/scarecrow/src"
 	"os"
+	scarecrow "github.com/aichaos/scarecrow/src"
+	_ "github.com/aichaos/scarecrow/src/listeners/console"
+	_ "github.com/aichaos/scarecrow/src/listeners/slack"
 )
 
 func main() {

--- a/src/listeners/console/console.go
+++ b/src/listeners/console/console.go
@@ -2,9 +2,10 @@ package console
 
 import (
 	"fmt"
-	"github.com/aichaos/scarecrow/src/types"
-	"github.com/jprichardson/readline-go"
 	"os"
+	"github.com/jprichardson/readline-go"
+	"github.com/aichaos/scarecrow/src/types"
+	"github.com/aichaos/scarecrow/src/listeners"
 )
 
 type ConsoleListener struct {
@@ -17,9 +18,13 @@ type ConsoleListener struct {
 	readline chan string
 }
 
+func init() {
+	listeners.Register("Console", &ConsoleListener{})
+}
+
 // New creates a new Slack Listener.
-func New(config types.ListenerConfig, request chan types.ReplyRequest,
-	response chan types.ReplyAnswer) *ConsoleListener {
+func (self ConsoleListener) New(config types.ListenerConfig, request chan types.ReplyRequest,
+	response chan types.ReplyAnswer) listeners.Listener {
 	listener := new(ConsoleListener)
 	listener.requestChannel = request
 	listener.answerChannel = response
@@ -29,7 +34,7 @@ func New(config types.ListenerConfig, request chan types.ReplyRequest,
 	return listener
 }
 
-func (self *ConsoleListener) Start() {
+func (self ConsoleListener) Start() {
 	self.readline = make(chan string)
 	go self.ListenToConsole()
 	go self.MainLoop()


### PR DESCRIPTION
# Summary

This refactors the listener system so that they implement an interface, and it removes knowledge of specific listeners from the core source code.
# Changes
- Remove imports of the Slack and Console listeners from the core source and put it into the CLI front-end command.
- Implement interfaces.
# Bugfixes

Fixes #1 
